### PR TITLE
Convert to list-mode and fix list-mode file structure

### DIFF
--- a/yrt-pet/executables/CMakeLists.txt
+++ b/yrt-pet/executables/CMakeLists.txt
@@ -7,6 +7,7 @@ define_target_exe(yrtpet_forward_project recon/ForwardProject.cpp)
 define_target_exe(yrtpet_prepare_additive_correction recon/PrepareAdditiveCorrection.cpp)
 
 define_target_exe(yrtpet_convert_to_histogram conversion/ConvertToHistogram.cpp PluginOptionsHelper.cpp)
+define_target_exe(yrtpet_convert_to_listmodelut conversion/ConvertToListModeLUT.cpp PluginOptionsHelper.cpp)
 define_target_exe(yrtpet_cumulate_histograms conversion/CumulateHistograms.cpp PluginOptionsHelper.cpp)
 define_target_exe(yrtpet_histogram_to_listmode conversion/Histogram3DToListMode.cpp)
 

--- a/yrt-pet/executables/conversion/ConvertToListModeLUT.cpp
+++ b/yrt-pet/executables/conversion/ConvertToListModeLUT.cpp
@@ -93,14 +93,20 @@ int main(int argc, char** argv)
 
 		ListModeLUTOwned* lmOut_ptr = lmOut.get();
 		const ProjectionData* dataInput_ptr = dataInput.get();
+		const bool hasTOF = dataInput->hasTOF();
 #pragma omp parallel for default(none), \
-    firstprivate(lmOut_ptr, dataInput_ptr, numEvents)
+    firstprivate(lmOut_ptr, dataInput_ptr, numEvents, hasTOF)
 		for (bin_t evId = 0; evId < numEvents; evId++)
 		{
 			lmOut_ptr->setTimestampOfEvent(evId,
 			                               dataInput_ptr->getTimestamp(evId));
 			det_pair_t detPair = dataInput_ptr->getDetectorPair(evId);
 			lmOut_ptr->setDetectorIdsOfEvent(evId, detPair.d1, detPair.d2);
+			if (hasTOF)
+			{
+				lmOut_ptr->setTOFValueOfEvent(evId,
+				                              dataInput_ptr->getTOFValue(evId));
+			}
 		}
 
 		std::cout << "Writing file..." << std::endl;

--- a/yrt-pet/executables/conversion/ConvertToListModeLUT.cpp
+++ b/yrt-pet/executables/conversion/ConvertToListModeLUT.cpp
@@ -95,12 +95,12 @@ int main(int argc, char** argv)
 		const ProjectionData* dataInput_ptr = dataInput.get();
 #pragma omp parallel for default(none), \
     firstprivate(lmOut_ptr, dataInput_ptr, numEvents)
-		for (bin_t binId = 0; binId < numEvents; binId++)
+		for (bin_t evId = 0; evId < numEvents; evId++)
 		{
-			det_pair_t detPair = dataInput_ptr->getDetectorPair(binId);
-			lmOut_ptr->setDetectorIdsOfEvent(binId, detPair.d1, detPair.d2);
-			lmOut_ptr->setTimestampOfEvent(binId,
-			                               dataInput_ptr->getTimestamp(binId));
+			lmOut_ptr->setTimestampOfEvent(evId,
+			                               dataInput_ptr->getTimestamp(evId));
+			det_pair_t detPair = dataInput_ptr->getDetectorPair(evId);
+			lmOut_ptr->setDetectorIdsOfEvent(evId, detPair.d1, detPair.d2);
 		}
 
 		std::cout << "Writing file..." << std::endl;

--- a/yrt-pet/executables/conversion/ConvertToListModeLUT.cpp
+++ b/yrt-pet/executables/conversion/ConvertToListModeLUT.cpp
@@ -1,0 +1,122 @@
+/*
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
+
+#include "../PluginOptionsHelper.hpp"
+#include "datastruct/IO.hpp"
+#include "datastruct/projection/ListModeLUT.hpp"
+#include "datastruct/projection/SparseHistogram.hpp"
+#include "datastruct/scanner/Scanner.hpp"
+#include "utils/Assert.hpp"
+#include "utils/Globals.hpp"
+#include "utils/ReconstructionUtils.hpp"
+
+#include "omp.h"
+#include <cxxopts.hpp>
+#include <iostream>
+
+int main(int argc, char** argv)
+{
+	try
+	{
+		std::string scanner_fname;
+		std::string input_fname;
+		std::string input_format;
+		std::string out_fname;
+		int numThreads = -1;
+
+		Plugin::OptionsResult pluginOptionsResults;  // For plugins' options
+
+		// Parse command line arguments
+		cxxopts::Options options(argv[0],
+		                         "Convert any input format to a histogram");
+		options.positional_help("[optional args]").show_positional_help();
+
+		/* clang-format off */
+		options.add_options()
+		("s,scanner", "Scanner parameters file name", cxxopts::value<std::string>(scanner_fname))
+		("i,input", "Input file", cxxopts::value<std::string>(input_fname))
+		("f,format", "Input file format. Possible values: " +
+			IO::possibleFormats(Plugin::InputFormatsChoice::ONLYLISTMODES),
+			cxxopts::value<std::string>(input_format))
+		("o,out", "Output listmode filename", cxxopts::value<std::string>(out_fname))
+		("num_threads", "Number of threads to use", cxxopts::value<int>(numThreads))
+		("h,help", "Print help");
+		/* clang-format on */
+
+		// Add plugin options
+		PluginOptionsHelper::fillOptionsFromPlugins(
+		    options, Plugin::InputFormatsChoice::ONLYLISTMODES);
+
+		auto result = options.parse(argc, argv);
+		if (result.count("help"))
+		{
+			std::cout << options.help() << std::endl;
+			return 0;
+		}
+
+		std::vector<std::string> required_params = {"scanner", "input", "out",
+		                                            "format"};
+		bool missing_args = false;
+		for (auto& p : required_params)
+		{
+			if (result.count(p) == 0)
+			{
+				std::cerr << "Argument '" << p << "' missing" << std::endl;
+				missing_args = true;
+			}
+		}
+		if (missing_args)
+		{
+			std::cerr << options.help() << std::endl;
+			return -1;
+		}
+
+		// Parse plugin options
+		pluginOptionsResults =
+		    PluginOptionsHelper::convertPluginResultsToMap(result);
+
+		Globals::set_num_threads(numThreads);
+
+		auto scanner = std::make_unique<Scanner>(scanner_fname);
+
+		std::cout << "Reading input data..." << std::endl;
+		std::unique_ptr<ProjectionData> dataInput = IO::openProjectionData(
+		    input_fname, input_format, *scanner, pluginOptionsResults);
+
+		std::cout << "Generating output ListModeLUT..." << std::endl;
+		auto lmOut =
+		    std::make_unique<ListModeLUTOwned>(*scanner, dataInput->hasTOF());
+		const size_t numEvents = dataInput->count();
+		lmOut->allocate(numEvents);
+
+		ListModeLUTOwned* lmOut_ptr = lmOut.get();
+		const ProjectionData* dataInput_ptr = dataInput.get();
+#pragma omp parallel for default(none), \
+    firstprivate(lmOut_ptr, dataInput_ptr, numEvents)
+		for (bin_t binId = 0; binId < numEvents; binId++)
+		{
+			det_pair_t detPair = dataInput_ptr->getDetectorPair(binId);
+			lmOut_ptr->setDetectorIdsOfEvent(binId, detPair.d1, detPair.d2);
+			lmOut_ptr->setTimestampOfEvent(binId,
+			                               dataInput_ptr->getTimestamp(binId));
+		}
+
+		std::cout << "Writing file..." << std::endl;
+		lmOut->writeToFile(out_fname);
+
+		std::cout << "Done." << std::endl;
+		return 0;
+	}
+	catch (const cxxopts::exceptions::exception& e)
+	{
+		std::cerr << "Error parsing options: " << e.what() << std::endl;
+		return -1;
+	}
+	catch (const std::exception& e)
+	{
+		Util::printExceptionMessage(e);
+		return -1;
+	}
+}

--- a/yrt-pet/include/datastruct/projection/ListModeLUT.hpp
+++ b/yrt-pet/include/datastruct/projection/ListModeLUT.hpp
@@ -41,6 +41,7 @@ public:
 	void setDetectorId1OfEvent(bin_t eventId, det_id_t d1);
 	void setDetectorId2OfEvent(bin_t eventId, det_id_t d2);
 	void setDetectorIdsOfEvent(bin_t eventId, det_id_t d1, det_id_t d2);
+	void setTOFValueOfEvent(bin_t eventId, float tofValue);
 
 	Array1DBase<timestamp_t>* getTimestampArrayPtr() const;
 	Array1DBase<det_id_t>* getDetector1ArrayPtr() const;

--- a/yrt-pet/include/datastruct/projection/ListModeLUT.hpp
+++ b/yrt-pet/include/datastruct/projection/ListModeLUT.hpp
@@ -37,6 +37,7 @@ public:
 	transform_t getTransformOfFrame(frame_t frame) const override;
 	float getDurationOfFrame(frame_t frame) const override;
 
+	void setTimestampOfEvent(bin_t eventId, timestamp_t ts);
 	void setDetectorId1OfEvent(bin_t eventId, det_id_t d1);
 	void setDetectorId2OfEvent(bin_t eventId, det_id_t d2);
 	void setDetectorIdsOfEvent(bin_t eventId, det_id_t d1, det_id_t d2);

--- a/yrt-pet/python/pyyrtpet/_pyyrtpet.py
+++ b/yrt-pet/python/pyyrtpet/_pyyrtpet.py
@@ -78,7 +78,7 @@ class DataFileRawd:
             data.tofile(fid)
 
 
-# Wrapper for Siddon operator
+# Wrapper for Projection operator
 class ProjectionOper:
     def __init__(self, scanner: yrt.Scanner, img_params: yrt.ImageParams,
                  projData: yrt.ProjectionData, projector='Siddon',

--- a/yrt-pet/src/datastruct/projection/ListModeLUT.cpp
+++ b/yrt-pet/src/datastruct/projection/ListModeLUT.cpp
@@ -33,9 +33,9 @@ void py_setup_listmodelut(py::module& m)
 	      {
 		      Array1DBase<timestamp_t>* arr = self.getTimestampArrayPtr();
 		      auto buf_info = py::buffer_info(
-			      arr->getRawPointer(), sizeof(timestamp_t),
-			      py::format_descriptor<timestamp_t>::format(), 1,
-			      {arr->getSizeTotal()}, {sizeof(timestamp_t)});
+		          arr->getRawPointer(), sizeof(timestamp_t),
+		          py::format_descriptor<timestamp_t>::format(), 1,
+		          {arr->getSizeTotal()}, {sizeof(timestamp_t)});
 		      return py::array_t<timestamp_t>(buf_info);
 	      });
 	c.def("getDetector1Array",
@@ -43,9 +43,9 @@ void py_setup_listmodelut(py::module& m)
 	      {
 		      Array1DBase<det_id_t>* arr = self.getDetector1ArrayPtr();
 		      auto buf_info =
-			      py::buffer_info(arr->getRawPointer(), sizeof(det_id_t),
-			                      py::format_descriptor<det_id_t>::format(), 1,
-			                      {arr->getSizeTotal()}, {sizeof(det_id_t)});
+		          py::buffer_info(arr->getRawPointer(), sizeof(det_id_t),
+		                          py::format_descriptor<det_id_t>::format(), 1,
+		                          {arr->getSizeTotal()}, {sizeof(det_id_t)});
 		      return py::array_t<det_id_t>(buf_info);
 	      });
 	c.def("getDetector2Array",
@@ -53,9 +53,9 @@ void py_setup_listmodelut(py::module& m)
 	      {
 		      Array1DBase<det_id_t>* arr = self.getDetector2ArrayPtr();
 		      auto buf_info =
-			      py::buffer_info(arr->getRawPointer(), sizeof(det_id_t),
-			                      py::format_descriptor<det_id_t>::format(), 1,
-			                      {arr->getSizeTotal()}, {sizeof(det_id_t)});
+		          py::buffer_info(arr->getRawPointer(), sizeof(det_id_t),
+		                          py::format_descriptor<det_id_t>::format(), 1,
+		                          {arr->getSizeTotal()}, {sizeof(det_id_t)});
 		      return py::array_t<det_id_t>(buf_info);
 	      });
 	c.def("addLORMotion", &ListModeLUT::addLORMotion);
@@ -64,31 +64,31 @@ void py_setup_listmodelut(py::module& m)
 	c.def("getNativeLORFromId", &ListModeLUT::getNativeLORFromId);
 
 	auto c_alias =
-		py::class_<ListModeLUTAlias, ListModeLUT>(m, "ListModeLUTAlias");
+	    py::class_<ListModeLUTAlias, ListModeLUT>(m, "ListModeLUTAlias");
 	c_alias.def(py::init<const Scanner&, bool>(), py::arg("scanner"),
 	            py::arg("flag_tof") = false);
 
 	c_alias.def("bind",
 	            static_cast<void (ListModeLUTAlias::*)(
-		            pybind11::array_t<timestamp_t, pybind11::array::c_style>&,
-		            pybind11::array_t<det_id_t, pybind11::array::c_style>&,
-		            pybind11::array_t<det_id_t, pybind11::array::c_style>&)>(
-		            &ListModeLUTAlias::bind),
+	                pybind11::array_t<timestamp_t, pybind11::array::c_style>&,
+	                pybind11::array_t<det_id_t, pybind11::array::c_style>&,
+	                pybind11::array_t<det_id_t, pybind11::array::c_style>&)>(
+	                &ListModeLUTAlias::bind),
 	            py::arg("timestamps"), py::arg("detector_ids1"),
 	            py::arg("detector_ids2"));
 	c_alias.def("bind",
 	            static_cast<void (ListModeLUTAlias::*)(
-		            pybind11::array_t<timestamp_t, pybind11::array::c_style>&,
-		            pybind11::array_t<det_id_t, pybind11::array::c_style>&,
-		            pybind11::array_t<det_id_t, pybind11::array::c_style>&,
-		            pybind11::array_t<float, pybind11::array::c_style>&)>(
-		            &ListModeLUTAlias::bind),
+	                pybind11::array_t<timestamp_t, pybind11::array::c_style>&,
+	                pybind11::array_t<det_id_t, pybind11::array::c_style>&,
+	                pybind11::array_t<det_id_t, pybind11::array::c_style>&,
+	                pybind11::array_t<float, pybind11::array::c_style>&)>(
+	                &ListModeLUTAlias::bind),
 	            py::arg("timestamps"), py::arg("detector_ids1"),
 	            py::arg("detector_ids2"), py::arg("tof_ps"));
 
 
 	auto c_owned =
-		py::class_<ListModeLUTOwned, ListModeLUT>(m, "ListModeLUTOwned");
+	    py::class_<ListModeLUTOwned, ListModeLUT>(m, "ListModeLUTOwned");
 	c_owned.def(py::init<const Scanner&, bool>(), py::arg("scanner"),
 	            py::arg("flag_tof") = false);
 	c_owned.def(py::init<const Scanner&, const std::string&, bool>(),
@@ -96,23 +96,22 @@ void py_setup_listmodelut(py::module& m)
 	            py::arg("flag_tof") = false);
 	c_owned.def("readFromFile", &ListModeLUTOwned::readFromFile);
 	c_owned.def("allocate", &ListModeLUTOwned::allocate);
-	c_owned.def("createFromHistogram3D",
-	            [](ListModeLUTOwned* self, const Histogram3D* histo,
-	               size_t num_events)
-	            {
-		            Util::histogram3DToListModeLUT(histo, self, num_events);
-	            });
+	c_owned.def(
+	    "createFromHistogram3D",
+	    [](ListModeLUTOwned* self, const Histogram3D* histo, size_t num_events)
+	    { Util::histogram3DToListModeLUT(histo, self, num_events); });
 }
 
 #endif  // if BUILD_PYBIND11
 
 
 ListModeLUT::ListModeLUT(const Scanner& pr_scanner, bool p_flagTOF)
-	: ListMode(pr_scanner),
-	  m_flagTOF(p_flagTOF) {}
+    : ListMode(pr_scanner), m_flagTOF(p_flagTOF)
+{
+}
 
 ListModeLUTOwned::ListModeLUTOwned(const Scanner& pr_scanner, bool p_flagTOF)
-	: ListModeLUT(pr_scanner, p_flagTOF)
+    : ListModeLUT(pr_scanner, p_flagTOF)
 {
 	mp_timestamps = std::make_unique<Array1D<timestamp_t>>();
 	mp_detectorId1 = std::make_unique<Array1D<det_id_t>>();
@@ -126,13 +125,13 @@ ListModeLUTOwned::ListModeLUTOwned(const Scanner& pr_scanner, bool p_flagTOF)
 ListModeLUTOwned::ListModeLUTOwned(const Scanner& pr_scanner,
                                    const std::string& listMode_fname,
                                    bool p_flagTOF)
-	: ListModeLUTOwned(pr_scanner, p_flagTOF)
+    : ListModeLUTOwned(pr_scanner, p_flagTOF)
 {
 	ListModeLUTOwned::readFromFile(listMode_fname);
 }
 
 ListModeLUTAlias::ListModeLUTAlias(const Scanner& pr_scanner, bool p_flagTOF)
-	: ListModeLUT(pr_scanner, p_flagTOF)
+    : ListModeLUT(pr_scanner, p_flagTOF)
 {
 	mp_timestamps = std::make_unique<Array1DAlias<timestamp_t>>();
 	mp_detectorId1 = std::make_unique<Array1DAlias<det_id_t>>();
@@ -159,12 +158,12 @@ void ListModeLUTOwned::readFromFile(const std::string& listMode_fname)
 	fin.seekg(0, std::ios::beg);
 	size_t begin = fin.tellg();
 	size_t file_size = end - begin;
-	int num_fields = m_flagTOF ? 4 : 3;
-	size_t sizeOfAnEvent = num_fields * sizeof(float);
+	int numFields = m_flagTOF ? 4 : 3;
+	size_t sizeOfAnEvent = numFields * sizeof(float);
 	if (file_size <= 0 || (file_size % sizeOfAnEvent) != 0)
 	{
 		throw std::runtime_error("Error: Input file has incorrect size in "
-			"ListModeLUTOwned::readFromFile.");
+		                         "ListModeLUTOwned::readFromFile.");
 	}
 
 	// Allocate the memory
@@ -172,65 +171,65 @@ void ListModeLUTOwned::readFromFile(const std::string& listMode_fname)
 	allocate(numEvents);
 
 	// Read content of file
-	size_t buffer_size = (size_t(1) << 30);
-	auto buff = std::make_unique<float[]>(buffer_size);
-	size_t pos_start = 0;
-	while (pos_start < numEvents)
+	size_t bufferSize = (size_t(1) << 30);
+	auto buff = std::make_unique<uint32_t[]>(bufferSize);
+	size_t posStart = 0;
+	while (posStart < numEvents)
 	{
-		size_t read_size =
-			std::min(buffer_size, num_fields * (numEvents - pos_start));
+		size_t readSize =
+		    std::min(bufferSize, numFields * (numEvents - posStart));
 		fin.read((char*)buff.get(),
-		         (read_size / num_fields) * num_fields * sizeof(float));
+		         (readSize / numFields) * numFields * sizeof(float));
 
-		int num_threads = Globals::get_num_threads();
-#pragma omp parallel for num_threads(num_threads)
-		for (size_t i = 0; i < read_size / num_fields; i++)
+#pragma omp parallel for default(none),                                     \
+    shared(mp_timestamps, mp_detectorId1, mp_detectorId2, buff, mp_tof_ps), \
+    firstprivate(readSize, numFields, posStart)
+		for (size_t i = 0; i < readSize / numFields; i++)
 		{
-			(*mp_timestamps)[pos_start + i] = buff[num_fields * i];
-			(*mp_detectorId1)[pos_start + i] =
-				*(reinterpret_cast<det_id_t*>(&(buff[num_fields * i + 1])));
-			(*mp_detectorId2)[pos_start + i] =
-				*(reinterpret_cast<det_id_t*>(&(buff[num_fields * i + 2])));
+			(*mp_timestamps)[posStart + i] = buff[numFields * i];
+			(*mp_detectorId1)[posStart + i] = buff[numFields * i + 1];
+			(*mp_detectorId2)[posStart + i] = buff[numFields * i + 2];
 			if (m_flagTOF)
 			{
-				(*mp_tof_ps)[pos_start + i] = buff[num_fields * i + 3];
+				std::memcpy(&mp_tof_ps->getRawPointer()[posStart + i],
+				            &buff[numFields * i + 3], sizeof(float));
 			}
 		}
-		pos_start += read_size / num_fields;
+		posStart += readSize / numFields;
 	}
 }
 
 void ListModeLUT::writeToFile(const std::string& listMode_fname) const
 {
-	int num_fields = m_flagTOF ? 4 : 3;
+	int numFields = m_flagTOF ? 4 : 3;
 	size_t numEvents = count();
 	std::ofstream file;
 	file.open(listMode_fname.c_str(), std::ios::binary | std::ios::out);
 
 	size_t bufferSize = (size_t(1) << 30);
-	auto buff = std::make_unique<float[]>(bufferSize);
+	auto buff = std::make_unique<uint32_t[]>(bufferSize);
 	// This is done assuming that "int" and "float" are of the same size
 	// (4bytes)
 	size_t posStart = 0;
 	while (posStart < numEvents)
 	{
 		size_t writeSize =
-			std::min(bufferSize, num_fields * (numEvents - posStart));
-		for (size_t i = 0; i < writeSize / num_fields; i++)
+		    std::min(bufferSize, numFields * (numEvents - posStart));
+		for (size_t i = 0; i < writeSize / numFields; i++)
 		{
-			buff[num_fields * i] = (*mp_timestamps)[posStart + i];
-			buff[num_fields * i + 1] =
-				*(reinterpret_cast<float*>(&(*mp_detectorId1)[posStart + i]));
-			buff[num_fields * i + 2] =
-				*(reinterpret_cast<float*>(&(*mp_detectorId2)[posStart + i]));
+			buff[numFields * i] = mp_timestamps->getFlat(posStart + i);
+			buff[numFields * i + 1] = mp_detectorId1->getFlat(posStart + i);
+			buff[numFields * i + 2] = mp_detectorId2->getFlat(posStart + i);
 			if (m_flagTOF)
 			{
-				buff[num_fields * i + 3] = (*mp_tof_ps)[posStart + i];
+				std::memcpy(&buff[numFields * i + 3],
+				            &mp_tof_ps->getRawPointer()[posStart + i],
+				            sizeof(float));
 			}
 		}
-		file.write((char*)buff.get(),
-		           (writeSize / num_fields) * num_fields * sizeof(float));
-		posStart += writeSize / num_fields;
+		file.write(reinterpret_cast<char*>(buff.get()),
+		           (writeSize / numFields) * numFields * sizeof(uint32_t));
+		posStart += writeSize / numFields;
 	}
 	file.close();
 }
@@ -244,7 +243,7 @@ void ListModeLUT::addLORMotion(const std::string& lorMotion_fname)
 
 	// Populate the frames
 	const frame_t numFrames =
-		static_cast<frame_t>(mp_lorMotion->getNumFrames());
+	    static_cast<frame_t>(mp_lorMotion->getNumFrames());
 	bin_t evId = 0;
 
 	// Skip the events that are before the first frame
@@ -260,7 +259,7 @@ void ListModeLUT::addLORMotion(const std::string& lorMotion_fname)
 	for (currentFrame = 0; currentFrame < numFrames - 1; currentFrame++)
 	{
 		const timestamp_t endingTimestamp =
-			mp_lorMotion->getStartingTimestamp(currentFrame + 1);
+		    mp_lorMotion->getStartingTimestamp(currentFrame + 1);
 		while (evId < numEvents && getTimestamp(evId) < endingTimestamp)
 		{
 			mp_frames->setFlat(evId, currentFrame);
@@ -350,8 +349,7 @@ void ListModeLUT::setDetectorId2OfEvent(bin_t eventId, det_id_t d2)
 	(*mp_detectorId2)[eventId] = d2;
 }
 
-void ListModeLUT::setDetectorIdsOfEvent(bin_t eventId, det_id_t d1,
-                                        det_id_t d2)
+void ListModeLUT::setDetectorIdsOfEvent(bin_t eventId, det_id_t d1, det_id_t d2)
 {
 	(*mp_detectorId1)[eventId] = d1;
 	(*mp_detectorId2)[eventId] = d2;
@@ -385,7 +383,7 @@ bool ListModeLUT::hasTOF() const
 void ListModeLUTOwned::allocate(size_t numEvents)
 {
 	static_cast<Array1D<timestamp_t>*>(mp_timestamps.get())
-		->allocate(numEvents);
+	    ->allocate(numEvents);
 	static_cast<Array1D<det_id_t>*>(mp_detectorId1.get())->allocate(numEvents);
 	static_cast<Array1D<det_id_t>*>(mp_detectorId2.get())->allocate(numEvents);
 	if (m_flagTOF)
@@ -410,7 +408,7 @@ float ListModeLUT::getTOFValue(bin_t eventId) const
 		return (*mp_tof_ps)[eventId];
 	else
 		throw std::logic_error(
-			"The given ListMode does not have any TOF values");
+		    "The given ListMode does not have any TOF values");
 }
 
 void ListModeLUTAlias::bind(ListModeLUT* listMode)
@@ -425,17 +423,17 @@ void ListModeLUTAlias::bind(Array1DBase<timestamp_t>* pp_timestamps,
                             Array1DBase<float>* pp_tof_ps)
 {
 	static_cast<Array1DAlias<timestamp_t>*>(mp_timestamps.get())
-		->bind(*pp_timestamps);
+	    ->bind(*pp_timestamps);
 	if (mp_timestamps->getRawPointer() == nullptr)
 		throw std::runtime_error("The timestamps array could not be bound");
 
 	static_cast<Array1DAlias<det_id_t>*>(mp_detectorId1.get())
-		->bind(*pp_detectorIds1);
+	    ->bind(*pp_detectorIds1);
 	if (mp_detectorId1->getRawPointer() == nullptr)
 		throw std::runtime_error("The detector_ids1 array could not be bound");
 
 	static_cast<Array1DAlias<det_id_t>*>(mp_detectorId2.get())
-		->bind(*pp_detectorIds2);
+	    ->bind(*pp_detectorIds2);
 	if (mp_detectorId2->getRawPointer() == nullptr)
 		throw std::runtime_error("The detector_ids2 array could not be bound");
 
@@ -449,62 +447,62 @@ void ListModeLUTAlias::bind(Array1DBase<timestamp_t>* pp_timestamps,
 
 #if BUILD_PYBIND11
 void ListModeLUTAlias::bind(
-	pybind11::array_t<timestamp_t, pybind11::array::c_style>& p_timestamps,
-	pybind11::array_t<det_id_t, pybind11::array::c_style>& p_detectorIds1,
-	pybind11::array_t<det_id_t, pybind11::array::c_style>& p_detectorIds2)
+    pybind11::array_t<timestamp_t, pybind11::array::c_style>& p_timestamps,
+    pybind11::array_t<det_id_t, pybind11::array::c_style>& p_detectorIds1,
+    pybind11::array_t<det_id_t, pybind11::array::c_style>& p_detectorIds2)
 {
 	pybind11::buffer_info buffer1 = p_timestamps.request();
 	if (buffer1.ndim != 1)
 	{
 		throw std::invalid_argument(
-			"The timestamps buffer has to be 1-dimensional");
+		    "The timestamps buffer has to be 1-dimensional");
 	}
 	static_cast<Array1DAlias<timestamp_t>*>(mp_timestamps.get())
-		->bind(reinterpret_cast<timestamp_t*>(buffer1.ptr), buffer1.shape[0]);
+	    ->bind(reinterpret_cast<timestamp_t*>(buffer1.ptr), buffer1.shape[0]);
 
 	pybind11::buffer_info buffer2 = p_detectorIds1.request();
 	if (buffer2.ndim != 1)
 	{
 		throw std::invalid_argument(
-			"The detector_ids1 buffer has to be 1-dimensional");
+		    "The detector_ids1 buffer has to be 1-dimensional");
 	}
 	static_cast<Array1DAlias<det_id_t>*>(mp_detectorId1.get())
-		->bind(reinterpret_cast<det_id_t*>(buffer2.ptr), buffer2.shape[0]);
+	    ->bind(reinterpret_cast<det_id_t*>(buffer2.ptr), buffer2.shape[0]);
 
 	pybind11::buffer_info buffer3 = p_detectorIds2.request();
 	if (buffer3.ndim != 1)
 	{
 		throw std::invalid_argument(
-			"The detector_ids2 buffer has to be 1-dimensional");
+		    "The detector_ids2 buffer has to be 1-dimensional");
 	}
 	static_cast<Array1DAlias<det_id_t>*>(mp_detectorId2.get())
-		->bind(reinterpret_cast<det_id_t*>(buffer3.ptr), buffer3.shape[0]);
+	    ->bind(reinterpret_cast<det_id_t*>(buffer3.ptr), buffer3.shape[0]);
 }
 
 void ListModeLUTAlias::bind(
-	pybind11::array_t<timestamp_t, pybind11::array::c_style>& p_timestamps,
-	pybind11::array_t<det_id_t, pybind11::array::c_style>& p_detector_ids1,
-	pybind11::array_t<det_id_t, pybind11::array::c_style>& p_detector_ids2,
-	pybind11::array_t<float, pybind11::array::c_style>& p_tof_ps)
+    pybind11::array_t<timestamp_t, pybind11::array::c_style>& p_timestamps,
+    pybind11::array_t<det_id_t, pybind11::array::c_style>& p_detector_ids1,
+    pybind11::array_t<det_id_t, pybind11::array::c_style>& p_detector_ids2,
+    pybind11::array_t<float, pybind11::array::c_style>& p_tof_ps)
 {
 	bind(p_timestamps, p_detector_ids1, p_detector_ids2);
 	if (!m_flagTOF)
 		throw std::logic_error(
-			"The ListMode was not created with flag_tof at true");
+		    "The ListMode was not created with flag_tof at true");
 	pybind11::buffer_info buffer = p_tof_ps.request();
 	if (buffer.ndim != 1)
 	{
 		throw std::invalid_argument("The TOF buffer has to be 1-dimensional");
 	}
 	static_cast<Array1DAlias<float>*>(mp_tof_ps.get())
-		->bind(reinterpret_cast<float*>(buffer.ptr), buffer.shape[0]);
+	    ->bind(reinterpret_cast<float*>(buffer.ptr), buffer.shape[0]);
 }
 #endif
 
 std::unique_ptr<ProjectionData>
-	ListModeLUTOwned::create(const Scanner& scanner,
-	                         const std::string& filename,
-	                         const Plugin::OptionsResult& pluginOptions)
+    ListModeLUTOwned::create(const Scanner& scanner,
+                             const std::string& filename,
+                             const Plugin::OptionsResult& pluginOptions)
 {
 	const auto flagTOF_it = pluginOptions.find("flag_tof");
 	bool flagTOF = flagTOF_it != pluginOptions.end();

--- a/yrt-pet/src/datastruct/projection/ListModeLUT.cpp
+++ b/yrt-pet/src/datastruct/projection/ListModeLUT.cpp
@@ -335,6 +335,11 @@ float ListModeLUT::getDurationOfFrame(frame_t frame) const
 	return ProjectionData::getDurationOfFrame(frame);
 }
 
+void ListModeLUT::setTimestampOfEvent(bin_t eventId, timestamp_t ts)
+{
+	(*mp_timestamps)[eventId] = ts;
+}
+
 void ListModeLUT::setDetectorId1OfEvent(bin_t eventId, det_id_t d1)
 {
 	(*mp_detectorId1)[eventId] = d1;

--- a/yrt-pet/src/datastruct/projection/ListModeLUT.cpp
+++ b/yrt-pet/src/datastruct/projection/ListModeLUT.cpp
@@ -12,6 +12,7 @@
 #include "utils/ReconstructionUtils.hpp"
 
 #include <cmath>
+#include <cstring>
 #include <fstream>
 #include <vector>
 

--- a/yrt-pet/src/datastruct/projection/ListModeLUT.cpp
+++ b/yrt-pet/src/datastruct/projection/ListModeLUT.cpp
@@ -356,6 +356,12 @@ void ListModeLUT::setDetectorIdsOfEvent(bin_t eventId, det_id_t d1, det_id_t d2)
 	(*mp_detectorId2)[eventId] = d2;
 }
 
+void ListModeLUT::setTOFValueOfEvent(bin_t eventId, float tofValue)
+{
+	ASSERT_MSG(hasTOF(), "TOF not set in the list-mode");
+	(*mp_tof_ps)[eventId] = tofValue;
+}
+
 Array1DBase<timestamp_t>* ListModeLUT::getTimestampArrayPtr() const
 {
 	return (mp_timestamps.get());

--- a/yrt-pet/src/datastruct/projection/ListModeLUT.cpp
+++ b/yrt-pet/src/datastruct/projection/ListModeLUT.cpp
@@ -149,8 +149,7 @@ void ListModeLUTOwned::readFromFile(const std::string& listMode_fname)
 
 	if (!fin.good())
 	{
-		throw std::runtime_error("Error reading input file " + listMode_fname +
-		                         "ListModeLUTOwned::readFromFile.");
+		throw std::runtime_error("Error reading input file " + listMode_fname);
 	}
 
 	// first check that file has the right size:

--- a/yrt-pet/src/datastruct/projection/ListModeLUTDOI.cpp
+++ b/yrt-pet/src/datastruct/projection/ListModeLUTDOI.cpp
@@ -116,8 +116,7 @@ void ListModeLUTDOIOwned::readFromFile(const std::string& listMode_fname)
 	std::ifstream fin(listMode_fname, std::ios::in | std::ios::binary);
 	if (!fin.good())
 	{
-		throw std::runtime_error("Error reading input file " + listMode_fname +
-		                         "ListModeLUTDOIOwned::readFromFile.");
+		throw std::runtime_error("Error reading input file " + listMode_fname);
 	}
 
 	// first check that file has the right size:

--- a/yrt-pet/src/datastruct/projection/ListModeLUTDOI.cpp
+++ b/yrt-pet/src/datastruct/projection/ListModeLUTDOI.cpp
@@ -156,7 +156,7 @@ void ListModeLUTDOIOwned::readFromFile(const std::string& listMode_fname)
 		for (size_t i = 0; i < numEventsBatchCurr; i++)
 		{
 			(*mp_timestamps)[eventStart + i] =
-			    *(reinterpret_cast<float*>(&(buff[sizeOfAnEvent * i])));
+			    *(reinterpret_cast<timestamp_t*>(&(buff[sizeOfAnEvent * i])));
 			(*mp_detectorId1)[eventStart + i] =
 			    *(reinterpret_cast<det_id_t*>(&(buff[sizeOfAnEvent * i + 4])));
 			(*mp_doi1)[eventStart + i] = buff[sizeOfAnEvent * i + 8];
@@ -225,22 +225,18 @@ void ListModeLUTDOI::writeToFile(const std::string& listMode_fname) const
 		size_t writeSize = numEventsBatchCurr * sizeOfAnEvent;
 		for (size_t i = 0; i < numEventsBatchCurr; i++)
 		{
-			memcpy(&buff[sizeOfAnEvent * i],
-			       reinterpret_cast<char*>(&(*mp_timestamps)[eventStart + i]),
-			       sizeof(float));
+			memcpy(&buff[sizeOfAnEvent * i], &(*mp_timestamps)[eventStart + i],
+			       sizeof(timestamp_t));
 			memcpy(&buff[sizeOfAnEvent * i + 4],
-			       reinterpret_cast<char*>(&(*mp_detectorId1)[eventStart + i]),
-			       sizeof(det_id_t));
+			       &(*mp_detectorId1)[eventStart + i], sizeof(det_id_t));
 			buff[sizeOfAnEvent * i + 8] = (*mp_doi1)[eventStart + i];
 			memcpy(&buff[sizeOfAnEvent * i + 9],
-			       reinterpret_cast<char*>(&(*mp_detectorId2)[eventStart + i]),
-			       sizeof(det_id_t));
+			       &(*mp_detectorId2)[eventStart + i], sizeof(det_id_t));
 			buff[sizeOfAnEvent * i + 13] = (*mp_doi2)[eventStart + i];
 			if (m_flagTOF)
 			{
 				memcpy(&buff[sizeOfAnEvent * i + 14],
-				       reinterpret_cast<char*>(&(*mp_tof_ps)[eventStart + i]),
-				       sizeof(float));
+				       &(*mp_tof_ps)[eventStart + i], sizeof(float));
 			}
 		}
 		file.write((char*)buff.get(), writeSize);

--- a/yrt-pet/src/datastruct/projection/ProjectionData.cpp
+++ b/yrt-pet/src/datastruct/projection/ProjectionData.cpp
@@ -24,6 +24,7 @@ void py_setup_projectiondata(py::module& m)
 	      py::arg("id"));
 	c.def("setProjectionValue", &ProjectionData::setProjectionValue,
 	      py::arg("id"), py::arg("value"));
+	c.def("getTimestamp", &ProjectionData::getTimestamp, py::arg("id"));
 	c.def("getFrame", &ProjectionData::getFrame, py::arg("id"));
 	c.def("getDetector1", &ProjectionData::getDetector1, py::arg("id"));
 	c.def("getDetector2", &ProjectionData::getDetector2, py::arg("id"));

--- a/yrt-pet/src/datastruct/projection/ProjectionData.cpp
+++ b/yrt-pet/src/datastruct/projection/ProjectionData.cpp
@@ -42,6 +42,9 @@ void py_setup_projectiondata(py::module& m)
 	c.def("getNumFrames", &ProjectionData::getNumFrames);
 	c.def("getTransformOfFrame", &ProjectionData::getTransformOfFrame,
 	      py::arg("frame"));
+	c.def("getDurationOfFrame", &ProjectionData::getDurationOfFrame,
+	      py::arg("frame"));
+	c.def("getScanDuration", &ProjectionData::getScanDuration);
 	c.def("hasTOF", &ProjectionData::hasTOF);
 	c.def("getTOFValue", &ProjectionData::getTOFValue, py::arg("id"));
 	c.def("getRandomsEstimate", &ProjectionData::getRandomsEstimate,

--- a/yrt-pet/src/datastruct/projection/SparseHistogram.cpp
+++ b/yrt-pet/src/datastruct/projection/SparseHistogram.cpp
@@ -9,8 +9,8 @@
 #include <cstring>
 
 #if BUILD_PYBIND11
-#include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
 
 using namespace pybind11::literals;
 namespace py = pybind11;
@@ -21,20 +21,29 @@ void py_setup_sparsehistogram(py::module& m)
 	c.def(py::init<const Scanner&>(), "scanner"_a);
 	c.def(py::init<const Scanner&, const std::string&>(), "scanner"_a,
 	      "filename"_a);
-	c.def(py::init<const Scanner&, const ProjectionData&,
-	               const BinIterator*>(),
+	c.def(py::init<const Scanner&, const ProjectionData&, const BinIterator*>(),
 	      "scanner"_a, "projectionData"_a, "binIterator"_a = nullptr);
 	c.def("allocate", &SparseHistogram::allocate, "numBins"_a);
-	c.def("accumulate",
-	      static_cast<void (SparseHistogram::*)(det_pair_t detPair,
-	                                              float projValue)>(
-	          &SparseHistogram::accumulate),
-	      "detPair"_a, "projValue"_a);
-	c.def("accumulate",
-	      static_cast<void (SparseHistogram::*)(
-	          const ProjectionData& projData, const BinIterator* binIter)>(
-	          &SparseHistogram::accumulate),
-	      "projData"_a, "binIter"_a = nullptr);
+	c.def(
+	    "accumulate",
+	    static_cast<void (SparseHistogram::*)(
+	        det_pair_t detPair, float projValue)>(&SparseHistogram::accumulate),
+	    "detPair"_a, "projValue"_a);
+	c.def(
+	    "accumulate",
+	    [](SparseHistogram& self, const ProjectionData& projData,
+	       bool ignoreZeros, const BinIterator* binIter)
+	    {
+		    if (ignoreZeros)
+		    {
+			    self.accumulate<true>(projData, binIter);
+		    }
+		    else
+		    {
+			    self.accumulate<false>(projData, binIter);
+		    }
+	    },
+	    "projData"_a, "ignoreZeros"_a = false, "binIter"_a = nullptr);
 	c.def("getProjectionValueFromDetPair",
 	      &SparseHistogram::getProjectionValueFromDetPair, "detPair"_a);
 	c.def("readFromFile", &SparseHistogram::readFromFile, "filename"_a);
@@ -42,10 +51,10 @@ void py_setup_sparsehistogram(py::module& m)
 	c.def("getProjValuesArray",
 	      [](SparseHistogram& self) -> pybind11::array_t<float>
 	      {
-		      const auto buf_info =
-		          py::buffer_info(self.getProjectionValuesBuffer(), sizeof(float),
-		                          py::format_descriptor<float>::format(), 1,
-		                          {self.count()}, {sizeof(float)});
+		      const auto buf_info = py::buffer_info(
+		          self.getProjectionValuesBuffer(), sizeof(float),
+		          py::format_descriptor<float>::format(), 1, {self.count()},
+		          {sizeof(float)});
 		      return py::array_t<float>(buf_info);
 	      });
 }
@@ -57,15 +66,15 @@ SparseHistogram::SparseHistogram(const Scanner& pr_scanner)
 }
 
 SparseHistogram::SparseHistogram(const Scanner& pr_scanner,
-                                     const std::string& filename)
+                                 const std::string& filename)
     : SparseHistogram(pr_scanner)
 {
 	readFromFile(filename);
 }
 
 SparseHistogram::SparseHistogram(const Scanner& pr_scanner,
-                                     const ProjectionData& pr_projData,
-                                     const BinIterator* pp_binIter)
+                                 const ProjectionData& pr_projData,
+                                 const BinIterator* pp_binIter)
     : SparseHistogram(pr_scanner)
 {
 	accumulate(pr_projData, pp_binIter);
@@ -80,7 +89,7 @@ void SparseHistogram::allocate(size_t numBins)
 
 template <bool IgnoreZeros>
 void SparseHistogram::accumulate(const ProjectionData& projData,
-                                   const BinIterator* binIter)
+                                 const BinIterator* binIter)
 {
 	size_t numBins;
 	if (binIter == nullptr)
@@ -114,12 +123,10 @@ void SparseHistogram::accumulate(const ProjectionData& projData,
 		accumulate(detPair, projValue);
 	}
 }
-template void
-    SparseHistogram::accumulate<true>(const ProjectionData& projData,
-                                        const BinIterator* binIter);
-template void
-    SparseHistogram::accumulate<false>(const ProjectionData& projData,
-                                         const BinIterator* binIter);
+template void SparseHistogram::accumulate<true>(const ProjectionData& projData,
+                                                const BinIterator* binIter);
+template void SparseHistogram::accumulate<false>(const ProjectionData& projData,
+                                                 const BinIterator* binIter);
 
 void SparseHistogram::accumulate(det_pair_t detPair, float projValue)
 {
@@ -179,8 +186,8 @@ det_pair_t SparseHistogram::getDetectorPair(bin_t id) const
 	return m_detPairs[id];
 }
 
-std::unique_ptr<BinIterator>
-    SparseHistogram::getBinIter(int numSubsets, int idxSubset) const
+std::unique_ptr<BinIterator> SparseHistogram::getBinIter(int numSubsets,
+                                                         int idxSubset) const
 {
 	ASSERT_MSG(idxSubset < numSubsets,
 	           "The subset index has to be smaller than the number of subsets");
@@ -188,7 +195,7 @@ std::unique_ptr<BinIterator>
 	           "Multiple subsets are not supported in sparse histograms");
 
 	return std::make_unique<BinIteratorChronological>(numSubsets, count(),
-	                                                    idxSubset);
+	                                                  idxSubset);
 }
 
 float SparseHistogram::getProjectionValue(bin_t id) const
@@ -344,9 +351,8 @@ det_pair_t SparseHistogram::SwapDetectorPairIfNeeded(det_pair_t detPair)
 }
 
 std::unique_ptr<ProjectionData>
-    SparseHistogram::create(const Scanner& scanner,
-                              const std::string& filename,
-                              const Plugin::OptionsResult& pluginOptions)
+    SparseHistogram::create(const Scanner& scanner, const std::string& filename,
+                            const Plugin::OptionsResult& pluginOptions)
 {
 	(void)pluginOptions;
 	return std::make_unique<SparseHistogram>(scanner, filename);

--- a/yrt-pet/src/datastruct/projection/SparseHistogram.cpp
+++ b/yrt-pet/src/datastruct/projection/SparseHistogram.cpp
@@ -261,8 +261,7 @@ void SparseHistogram::readFromFile(const std::string& filename)
 
 	if (!ifs.good())
 	{
-		throw std::runtime_error("Error reading input file " + filename +
-		                         "ListModeLUTOwned::readFromFile.");
+		throw std::runtime_error("Error reading input file " + filename);
 	}
 
 	constexpr std::streamsize sizeOfAnEvent_bytes =

--- a/yrt-pet/src/datastruct/scanner/DetCoord.cpp
+++ b/yrt-pet/src/datastruct/scanner/DetCoord.cpp
@@ -236,8 +236,7 @@ void DetCoordOwned::readFromFile(const std::string& filename)
 	std::ifstream fin(filename.c_str(), std::ios::in | std::ios::binary);
 	if (!fin.good())
 	{
-		throw std::runtime_error("Error reading input file " + filename +
-		                         " DetCoord::readDetCoords.");
+		throw std::runtime_error("Error reading input file " + filename);
 	}
 
 	// first check that file has the right size:

--- a/yrt-pet/src/motion/ImageWarperTemplate.cpp
+++ b/yrt-pet/src/motion/ImageWarperTemplate.cpp
@@ -481,7 +481,7 @@ void ImageWarperTemplate::setFrameTimeBinStart(float timeBinStart, int frameId)
 	// order.
 	if (timeBinStart >= 0.0)
 	{
-		m_frameTimeBinStart[frameId] = timeBinStart;
+		m_frameTimeBinStart[frameId] = 1000 * timeBinStart;  // Times are in ms
 	}
 	else
 	{


### PR DESCRIPTION
- Breaking fix: Fix the way The timestamps are read and written in the ListModeLUT the proper way.
	- They were read and written in float. Now they are read and written in uint32_t, as they should.
	- The same applies in the ListModeLUTDOI
	- Integration test files have been changed accordingly
- Add an executable that converts a listmode into a ListModeLUT
	- Required adding some setters in ListModeLUT
- Add more python bindings
	- Also add python binding for SparseHistogram's accumulate 
- Some formatting
- Fix the way the ImageWarper was operating with timestamps (units are in seconds inside the file, but must be in milliseconds inside memory)
