### PR TITLE
Fix NIfTI compression and filename handling

### DIFF
--- a/yrt-pet/CMakeLists.txt
+++ b/yrt-pet/CMakeLists.txt
@@ -5,6 +5,7 @@ project(yrt-pet VERSION 0.0.1 LANGUAGES CXX)
 
 
 # # Dependencies
+find_package(ZLIB REQUIRED)
 
 # CMake tools
 include(ExternalProject)
@@ -46,7 +47,7 @@ endif (USE_CUDA)
 
 # Common variables
 set(YRTPET_COMPILE_FEATURES cxx_std_17)
-set(YRTPET_LINK_LIBRARIES OpenMP::OpenMP_CXX)
+set(YRTPET_LINK_LIBRARIES OpenMP::OpenMP_CXX ZLIB::ZLIB)
 set(YRTPET_INCLUDE_DIRECTORIES)
 set(YRTPET_LIB_NAME yrtpet)
 
@@ -87,6 +88,7 @@ function(setup_target TARGET JSON CXXOPTS PYBIND11)
         target_link_libraries(${TARGET} PUBLIC ${Python_LIBRARIES})
         target_compile_definitions(${TARGET} PUBLIC BUILD_PYBIND11)
     endif ()
+    add_compile_definitions(HAVE_ZLIB)
 endfunction()
 
 # Wrapper for library target

--- a/yrt-pet/include/utils/Tools.hpp
+++ b/yrt-pet/include/utils/Tools.hpp
@@ -78,8 +78,8 @@ namespace Util
 		return s;
 	}
 
-	int maxNumberOfDigits(int n);
-	std::string padZeros(int number, int num_digits);
+	int numberOfDigits(int n);
+	std::string padZeros(int number, int numDigits);
 
 	template <typename T>
 	T getAttenuationCoefficientFactor(T proj, T unitFactor = 0.1)

--- a/yrt-pet/include/utils/Tools.hpp
+++ b/yrt-pet/include/utils/Tools.hpp
@@ -43,6 +43,7 @@ namespace Util
 
 	std::string addBeforeExtension(const std::string& fname,
 	                               const std::string& addition);
+	bool endsWith(const std::string& str, const std::string& suffix);
 
 	/**
 	 * Fills a given box by trilinear interpolation. It fills from the values at

--- a/yrt-pet/src/datastruct/image/Image.cpp
+++ b/yrt-pet/src/datastruct/image/Image.cpp
@@ -4,9 +4,11 @@
  */
 
 #include "datastruct/image/Image.hpp"
+
 #include "datastruct/image/ImageBase.hpp"
 #include "geometry/Constants.hpp"
 #include "utils/Assert.hpp"
+#include "utils/Tools.hpp"
 #include "utils/Types.hpp"
 #include "utils/Utilities.hpp"
 
@@ -758,6 +760,11 @@ void Image::assignImageInterpolate(const Vector3D& point, float value)
 // this function writes "image" on disk @ "image_fname"
 void Image::writeToFile(const std::string& fname) const
 {
+	ASSERT(!fname.empty());
+	ASSERT_MSG_WARNING(
+	    Util::endsWith(fname, ".nii") || Util::endsWith(fname, ".nii.gz"),
+	    "The NIfTI image file extension should be either .nii or .nii.gz");
+
 	const ImageParams& params = getParams();
 	const int dims[] = {3, params.nx, params.ny, params.nz};
 	nifti_image* nim = nifti_make_new_nim(dims, NIFTI_TYPE_FLOAT32, 0);
@@ -1027,6 +1034,12 @@ mat44 ImageOwned::adjustAffineMatrix(mat44 matrix)
 void ImageOwned::readFromFile(const std::string& fname)
 {
 	nifti_image* niftiImage = nifti_image_read(fname.c_str(), 1);
+
+	if (niftiImage == nullptr)
+	{
+		throw std::invalid_argument("An error occured while reading file" +
+		                            fname);
+	}
 
 	mat44 transformMatrix;
 	if (niftiImage->sform_code > 0)

--- a/yrt-pet/src/recon/OSEM.cpp
+++ b/yrt-pet/src/recon/OSEM.cpp
@@ -25,6 +25,7 @@
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 namespace py = pybind11;
+
 void py_setup_osem(pybind11::module& m)
 {
 	auto c = py::class_<OSEM>(m, "OSEM");
@@ -198,6 +199,10 @@ void OSEM::generateSensitivityImagesCore(
 
 	sensImages.clear();
 
+	const int numDigitsInFilename =
+	    num_OSEM_subsets > 1 ? Util::maxNumberOfDigits(num_OSEM_subsets - 1) :
+	                           1;
+
 	for (int subsetId = 0; subsetId < num_OSEM_subsets; subsetId++)
 	{
 		std::cout << "OSEM subset " << subsetId + 1 << "/" << num_OSEM_subsets
@@ -218,7 +223,8 @@ void OSEM::generateSensitivityImagesCore(
 			{
 				outFileName = Util::addBeforeExtension(
 				    out_fname,
-				    std::string("_subset") + std::to_string(subsetId));
+				    std::string("_subset") +
+				        Util::padZeros(subsetId, numDigitsInFilename));
 			}
 			generatedImage->writeToFile(outFileName);
 			std::cout << "Image saved." << std::endl;

--- a/yrt-pet/src/recon/OSEM.cpp
+++ b/yrt-pet/src/recon/OSEM.cpp
@@ -200,7 +200,7 @@ void OSEM::generateSensitivityImagesCore(
 	sensImages.clear();
 
 	const int numDigitsInFilename =
-	    num_OSEM_subsets > 1 ? Util::maxNumberOfDigits(num_OSEM_subsets - 1) :
+	    num_OSEM_subsets > 1 ? Util::numberOfDigits(num_OSEM_subsets - 1) :
 	                           1;
 
 	for (int subsetId = 0; subsetId < num_OSEM_subsets; subsetId++)
@@ -521,7 +521,7 @@ std::unique_ptr<ImageOwned> OSEM::reconstruct(const std::string& out_fname)
 	initializeForRecon();
 
 	const int numDigitsInFilename =
-	    Util::maxNumberOfDigits(num_MLEM_iterations);
+	    Util::numberOfDigits(num_MLEM_iterations);
 
 	// MLEM iterations
 	for (int iter = 0; iter < num_MLEM_iterations; iter++)
@@ -726,7 +726,7 @@ std::unique_ptr<ImageOwned>
 	}
 
 	const int num_digits_in_fname =
-	    Util::maxNumberOfDigits(num_MLEM_iterations);
+	    Util::numberOfDigits(num_MLEM_iterations);
 
 	/* MLEM iterations */
 	for (int iter = 0; iter < num_MLEM_iterations; iter++)

--- a/yrt-pet/src/utils/Tools.cpp
+++ b/yrt-pet/src/utils/Tools.cpp
@@ -371,14 +371,18 @@ namespace Util
 	template void fillBox(Array3DBase<double>& arr, size_t z1, size_t z2,
 	                      size_t y1, size_t y2, size_t x1, size_t x2);
 
-	int maxNumberOfDigits(int n)
+	int numberOfDigits(int n)
 	{
+		if (n == 0)
+		{
+			return 1;
+		}
 		return static_cast<int>(std::ceil(std::log10(n + 1)));
 	}
 
-	std::string padZeros(int number, int num_digits)
+	std::string padZeros(int number, int numDigits)
 	{
-		const int numberOfZerosToPad = num_digits - maxNumberOfDigits(number);
+		const int numberOfZerosToPad = numDigits - numberOfDigits(number);
 		if (numberOfZerosToPad < 0)
 		{
 			throw std::invalid_argument("The number given in padZeros "

--- a/yrt-pet/src/utils/Tools.cpp
+++ b/yrt-pet/src/utils/Tools.cpp
@@ -163,6 +163,13 @@ namespace Util
 		return fnameInserted;
 	}
 
+	bool endsWith(const std::string& str, const std::string& suffix)
+	{
+		return str.size() >= suffix.size() &&
+		       str.compare(str.size() - suffix.size(), suffix.size(), suffix) ==
+		           0;
+	}
+
 	template <typename T>
 	void conv3D_separable(const Array3DBase<T>& src,
 	                      const Array1DBase<T>& kernelX,

--- a/yrt-pet/src/utils/Tools.cpp
+++ b/yrt-pet/src/utils/Tools.cpp
@@ -132,12 +132,35 @@ namespace Util
 	std::string addBeforeExtension(const std::string& fname,
 	                               const std::string& addition)
 	{
-		std::string fname_inserted(fname);
-		size_t pos_where_insert = fname.find_last_of('.');
-		if (pos_where_insert == std::string::npos || pos_where_insert == 0)
-			pos_where_insert = fname_inserted.size();
-		fname_inserted = fname_inserted.insert(pos_where_insert, addition);
-		return fname_inserted;
+		int fnameSize = fname.size();
+		int pos = fnameSize - 1;
+		char lastTwoChars[2] = {0, 0};
+		int extensionPosition = -1;
+
+		// Insert before extension, except when the extension is .gz, then wait
+		// for the next extension
+		while (pos >= 0)
+		{
+			const char currentChar = fname[pos];
+			if (currentChar == '.')
+			{
+				if (!(lastTwoChars[0] == 'g' && lastTwoChars[1] == 'z'))
+				{
+					extensionPosition = pos;
+					break;
+				}
+			}
+			lastTwoChars[1] = lastTwoChars[0];
+			lastTwoChars[0] = currentChar;
+			pos--;
+		}
+		std::string fnameInserted(fname);
+
+		const size_t posWhereInsert =
+		    extensionPosition >= 0 ? extensionPosition : fnameSize;
+
+		fnameInserted = fnameInserted.insert(posWhereInsert, addition);
+		return fnameInserted;
 	}
 
 	template <typename T>


### PR DESCRIPTION
- Add dependency to `zlib` in order to support `.nii.gz` (gzip compression) files for reading and writing
- Change the way filename prefixes are handled in the case of an extra `.gz` extension (#8)
- Add warnings when the user tries to save an image without the proper supported extensions
- Add security checks when the NIfTI library failed to read an image
- Add zero-padding when saving sensitivity images for several subsets
- Minor renames