### PR TITLE
Fix savant name

### DIFF
--- a/doc/compilation/building.md
+++ b/doc/compilation/building.md
@@ -7,6 +7,7 @@
 - An internet connection to download the `cxxopts`, `nlohmann/json`,
   and `catch2` libraries
 - OpenMP, but this is baked into most compilers
+- zlib, to read NIfTI images in `.nii.gz` format.
 
 ## Configuration and Compilation
 

--- a/yrt-pet/include/operators/OperatorDevice.cuh
+++ b/yrt-pet/include/operators/OperatorDevice.cuh
@@ -61,7 +61,7 @@ public:
 
 	bool requiresIntermediaryProjData() const;
 
-	void setAttImage(const Image* attImage) override;
+	void setAttImageForForwardProjection(const Image* attImage) override;
 	void setAttImageForBackprojection(const Image* attImage) override;
 	void setAddHisto(const Histogram* p_addHisto) override;
 	void setupTOFHelper(float tofWidth_ps, int tofNumStd = -1);

--- a/yrt-pet/include/operators/OperatorProjector.hpp
+++ b/yrt-pet/include/operators/OperatorProjector.hpp
@@ -49,9 +49,8 @@ public:
 	const Scanner& getScanner() const;
 	const BinIterator* getBinIter() const;
 
-	virtual void setAttImage(const Image* p_attImage);  // alias
+	virtual void setAttImageForForwardProjection(const Image* p_attImage);  // alias
 	virtual void setAttImageForBackprojection(const Image* p_attImage);
-	void setAttenuationImage(const Image* p_attImage);
 	virtual void setAddHisto(const Histogram* p_addHisto);
 	void setBinIter(const BinIterator* p_binIter);
 

--- a/yrt-pet/include/recon/OSEM.hpp
+++ b/yrt-pet/include/recon/OSEM.hpp
@@ -80,7 +80,9 @@ public:
 	OperatorProjector::ProjectorType projectorType;
 	const Scanner& scanner;
 	const Image* maskImage;
+	// Typically the in-vivo attenuation image
 	const Image* attenuationImageForForwardProjection;
+	// Typically the hardware attenuation image
 	const Image* attenuationImageForBackprojection;
 	const Histogram* addHis;
 	ImageWarperTemplate* warper;  // For MLEM with Warper only

--- a/yrt-pet/integration_tests/helper.py
+++ b/yrt-pet/integration_tests/helper.py
@@ -209,7 +209,7 @@ dataset_paths = {'test_mlem_simple': 'offset_UMHotSpot_noMotion.lmDat',
                  'test_flat_panel_mlem_tof': [
                      'out_Large_panels_4min_singTres49ps_0_gc_R30_r0.lmDat',
                      'images/test_flat_sens_S.nii', 'images/test_flat_sens_DD_GPU.nii'],
-                 'test_subsets_savant': 'offset_UMHotSpot_noMotion.lmDat',
+                 'test_subsets_savant_sim': 'offset_UMHotSpot_noMotion.lmDat',
                  'test_adjoint_uhr2d': 'shepp_logan_2d.lmDat',
                  'test_osem_his_2d': 'shepp_logan_2d.his',
                  'test_osem_siddon_multi_ray':
@@ -261,7 +261,7 @@ util_paths = {'img_params_500': 'config/img_params_500.json',
               'img_params_192': 'config/img_params_192.json',
               'img_params_2mm': 'config/img_params_2mm.json',
               'img_params_2d': 'config/img_params_2d.json',
-              'SAVANT_json': 'config/SAVANT.json',
+              'SAVANT_sim_json': 'config/SAVANT_sim.json',
               'UHR2D_json': 'config/UHR2D.json',
               'Geometry_2panels_large_3x3x20mm_rot_gc_json':
                   'config/Geometry_2panels_large_3x3x20mm_rot_gc.json',

--- a/yrt-pet/integration_tests/test_recon.py
+++ b/yrt-pet/integration_tests/test_recon.py
@@ -33,7 +33,7 @@ def test_omp_multithreading():
 
 def test_mlem_simple():
     img_params = yrt.ImageParams(util_paths['img_params_500'])
-    scanner = yrt.Scanner(util_paths['SAVANT_json'])
+    scanner = yrt.Scanner(util_paths['SAVANT_sim_json'])
     dataset = yrt.ListModeLUTOwned(scanner, dataset_paths['test_mlem_simple'])
     sens_img = yrt.ImageOwned(img_params, util_paths['SensImageSAVANT500'])
     _helper._test_reconstruction(
@@ -46,7 +46,7 @@ def _test_mlem_helper(dset):
     """Helper function for motion MLEM tests"""
     test_name = 'test_mlem_{}'.format(dset)
     img_params = yrt.ImageParams(util_paths['img_params_500'])
-    scanner = yrt.Scanner(util_paths['SAVANT_json'])
+    scanner = yrt.Scanner(util_paths['SAVANT_sim_json'])
     dataset = yrt.ListModeLUTOwned(scanner, dataset_paths[test_name][0])
     sens_img = yrt.ImageOwned(img_params, util_paths['SensImageSAVANT500'])
 
@@ -73,7 +73,7 @@ def test_mlem_yesMan():
 
 def test_bwd():
     img_params = yrt.ImageParams(util_paths['img_params_500'])
-    scanner = yrt.Scanner(util_paths['SAVANT_json'])
+    scanner = yrt.Scanner(util_paths['SAVANT_sim_json'])
     dataset = yrt.ListModeLUTOwned(scanner, dataset_paths['test_bwd'])
 
     out_img = yrt.ImageOwned(img_params)
@@ -92,7 +92,7 @@ def test_bwd():
 
 def test_sens():
     img_params = yrt.ImageParams(util_paths['img_params_500'])
-    scanner = yrt.Scanner(util_paths['SAVANT_json'])
+    scanner = yrt.Scanner(util_paths['SAVANT_sim_json'])
 
     osem = yrt.createOSEM(scanner)
     osem.setImageParams(img_params)
@@ -109,7 +109,7 @@ def test_sens():
 
 def test_sens_exec():
     exec_str = os.path.join(fold_bin, 'yrtpet_reconstruct --sens_only')
-    exec_str += ' --scanner ' + util_paths['SAVANT_json']
+    exec_str += ' --scanner ' + util_paths['SAVANT_sim_json']
     exec_str += ' --params ' + util_paths['img_params_500']
     exec_str += ' --out_sens ' + out_paths['test_sens_exec']
     ret = os.system(exec_str)
@@ -122,7 +122,7 @@ def test_sens_exec():
                                np.array(ref_img, copy=False),
                                atol=0, rtol=1e-4)
 
-def _test_savant_motion_post_mc(test_name: str):
+def _test_savant_sim_motion_post_mc(test_name: str):
     img_params = yrt.ImageParams(util_paths['img_params_500'])
     file_list = dataset_paths[test_name]
     image_list = []
@@ -151,11 +151,11 @@ def _test_savant_motion_post_mc(test_name: str):
 
 
 def test_post_recon_mc_piston():
-    _test_savant_motion_post_mc('test_post_recon_mc_piston')
+    _test_savant_sim_motion_post_mc('test_post_recon_mc_piston')
 
 
 def test_post_recon_mc_wobble():
-    _test_savant_motion_post_mc('test_post_recon_mc_wobble')
+    _test_savant_sim_motion_post_mc('test_post_recon_mc_wobble')
 
 
 def test_psf():
@@ -273,17 +273,17 @@ def test_flat_panel_mlem_tof_exec():
     assert cur_nrmse < 1e-6
 
 
-def test_subsets_savant_siddon():
-    scanner = yrt.Scanner(util_paths["SAVANT_json"])
+def test_subsets_savant_sim_siddon():
+    scanner = yrt.Scanner(util_paths["SAVANT_sim_json"])
     img_params = yrt.ImageParams(util_paths["img_params_500"])
-    lm = yrt.ListModeLUTOwned(scanner, dataset_paths["test_subsets_savant"])
+    lm = yrt.ListModeLUTOwned(scanner, dataset_paths["test_subsets_savant_sim"])
     _helper._test_subsets(scanner, img_params, lm, projector='Siddon')
 
 
-def test_subsets_savant_dd():
-    scanner = yrt.Scanner(util_paths["SAVANT_json"])
+def test_subsets_savant_sim_dd():
+    scanner = yrt.Scanner(util_paths["SAVANT_sim_json"])
     img_params = yrt.ImageParams(util_paths["img_params_500"])
-    lm = yrt.ListModeLUTOwned(scanner, dataset_paths["test_subsets_savant"])
+    lm = yrt.ListModeLUTOwned(scanner, dataset_paths["test_subsets_savant_sim"])
     _helper._test_subsets(scanner, img_params, lm, projector='DD')
 
 
@@ -345,7 +345,7 @@ def test_osem_his_2d():
 def test_osem_siddon_multi_ray():
     num_siddon_rays = 6
     img_params = yrt.ImageParams(util_paths['img_params_500'])
-    scanner = yrt.Scanner(util_paths['SAVANT_json'])
+    scanner = yrt.Scanner(util_paths['SAVANT_sim_json'])
     dataset = yrt.ListModeLUTOwned(
         scanner, dataset_paths['test_osem_siddon_multi_ray'])
     sens_img = yrt.ImageOwned(

--- a/yrt-pet/src/operators/OperatorDevice.cu
+++ b/yrt-pet/src/operators/OperatorDevice.cu
@@ -205,9 +205,9 @@ void OperatorProjectorDevice::setupProjPsfManager(
 	           "Error occured during the setup of ProjectionPsfManagerDevice");
 }
 
-void OperatorProjectorDevice::setAttImage(const Image* attImage)
+void OperatorProjectorDevice::setAttImageForForwardProjection(const Image* attImage)
 {
-	OperatorProjectorBase::setAttImage(attImage);
+	OperatorProjectorBase::setAttImageForForwardProjection(attImage);
 
 	mp_attImageDevice = std::make_unique<ImageDeviceOwned>(
 	    attImage->getParams(), getAuxStream());

--- a/yrt-pet/src/operators/OperatorProjector.cpp
+++ b/yrt-pet/src/operators/OperatorProjector.cpp
@@ -129,14 +129,15 @@ void OperatorProjectorBase::setAttenuationImage(const Image* p_attImage)
 void OperatorProjectorBase::setAttImageForBackprojection(
     const Image* p_attImage)
 {
+	ASSERT_MSG(p_attImage != nullptr,
+			   "The attenuation image given is a null pointer");
 	attImageForBackprojection = p_attImage;
 }
 
 void OperatorProjectorBase::setAttImage(const Image* p_attImage)
 {
 	ASSERT_MSG(p_attImage != nullptr,
-	           "The attenuation image given in "
-	           "OperatorProjector::setAttenuationImage is a null pointer");
+	           "The attenuation image given is a null pointer");
 	attImageForForwardProjection = p_attImage;
 }
 

--- a/yrt-pet/src/operators/OperatorProjector.cpp
+++ b/yrt-pet/src/operators/OperatorProjector.cpp
@@ -48,8 +48,8 @@ void py_setup_operatorprojectorbase(py::module& m)
 	auto c =
 	    py::class_<OperatorProjectorBase, Operator>(m, "OperatorProjectorBase");
 	c.def("setAddHisto", &OperatorProjectorBase::setAddHisto);
-	c.def("setAttenuationImage", &OperatorProjectorBase::setAttenuationImage);
-	c.def("setAttImage", &OperatorProjectorBase::setAttenuationImage);
+	c.def("setAttImageForForwardProjection",
+	      &OperatorProjectorBase::setAttImageForForwardProjection);
 	c.def("setAttImageForBackprojection",
 	      &OperatorProjectorBase::setAttImageForBackprojection);
 	c.def("getBinIter", &OperatorProjectorBase::getBinIter);
@@ -121,20 +121,16 @@ void OperatorProjectorBase::setBinIter(const BinIterator* p_binIter)
 	binIter = p_binIter;
 }
 
-void OperatorProjectorBase::setAttenuationImage(const Image* p_attImage)
-{
-	setAttImage(p_attImage);
-}
-
 void OperatorProjectorBase::setAttImageForBackprojection(
     const Image* p_attImage)
 {
 	ASSERT_MSG(p_attImage != nullptr,
-			   "The attenuation image given is a null pointer");
+	           "The attenuation image given is a null pointer");
 	attImageForBackprojection = p_attImage;
 }
 
-void OperatorProjectorBase::setAttImage(const Image* p_attImage)
+void OperatorProjectorBase::setAttImageForForwardProjection(
+    const Image* p_attImage)
 {
 	ASSERT_MSG(p_attImage != nullptr,
 	           "The attenuation image given is a null pointer");

--- a/yrt-pet/src/recon/OSEM.cpp
+++ b/yrt-pet/src/recon/OSEM.cpp
@@ -718,7 +718,8 @@ std::unique_ptr<ImageOwned>
 	}
 	if (attenuationImageForForwardProjection != nullptr)
 	{
-		mp_projector->setAttenuationImage(attenuationImageForForwardProjection);
+		mp_projector->setAttImageForForwardProjection(
+		    attenuationImageForForwardProjection);
 	}
 
 	const int num_digits_in_fname = Util::numberOfDigits(num_MLEM_iterations);

--- a/yrt-pet/src/recon/OSEM_CPU.cpp
+++ b/yrt-pet/src/recon/OSEM_CPU.cpp
@@ -153,7 +153,8 @@ void OSEM_CPU::setupOperatorsForRecon()
 
 	if (attenuationImageForForwardProjection != nullptr)
 	{
-		mp_projector->setAttenuationImage(attenuationImageForForwardProjection);
+		mp_projector->setAttImageForForwardProjection(
+		    attenuationImageForForwardProjection);
 	}
 	if (addHis != nullptr)
 	{

--- a/yrt-pet/src/recon/OSEM_GPU.cu
+++ b/yrt-pet/src/recon/OSEM_GPU.cu
@@ -114,7 +114,8 @@ void OSEM_GPU::setupOperatorsForRecon()
 	    projParams, getMainStream(), getAuxStream());
 	if (attenuationImageForForwardProjection != nullptr)
 	{
-		mp_projector->setAttenuationImage(attenuationImageForForwardProjection);
+		mp_projector->setAttImageForForwardProjection(
+		    attenuationImageForForwardProjection);
 	}
 	if (addHis != nullptr)
 	{

--- a/yrt-pet/src/utils/ReconstructionUtils.cpp
+++ b/yrt-pet/src/utils/ReconstructionUtils.cpp
@@ -238,7 +238,7 @@ namespace Util
 
 		const Histogram3D* histoOut_constptr = &histoOut;
 		const ProjectionData* dat_constptr = &dat;
-#pragma omp parallel for default(none)                                         \
+#pragma omp parallel for default(none)                            \
     firstprivate(histoDataPointer, numDatBins, histoOut_constptr, \
                      dat_constptr) shared(progressBar)
 		for (bin_t datBin = 0; datBin < numDatBins; ++datBin)
@@ -363,7 +363,7 @@ namespace Util
 		{
 			if constexpr (IS_FWD)
 			{
-				oper->setAttenuationImage(attImage);
+				oper->setAttImageForForwardProjection(attImage);
 			}
 			else
 			{


### PR DESCRIPTION
- Fix name used in integration tests for SAVANT scanner used only from GATE simulation (different from the (future) real one).
- Rename `setAttImage` function for more coherence.
- Some formatting.